### PR TITLE
Id cast to string & removed from attributes

### DIFF
--- a/dist/yayson.js
+++ b/dist/yayson.js
@@ -1,5 +1,5 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-var Adapter, Q, adapters, lookupAdapter, presenter, presenterFactory, tryRequire, utils, _;
+var Adapter, Q, _, adapters, lookupAdapter, presenter, presenterFactory, tryRequire, utils;
 
 tryRequire = function(dep) {
   try {
@@ -42,9 +42,9 @@ presenter = function(options) {
   return presenterFactory(utils, adapter);
 };
 
-module.exports = function(_arg) {
+module.exports = function(arg) {
   var adapter;
-  adapter = (_arg != null ? _arg : {}).adapter;
+  adapter = (arg != null ? arg : {}).adapter;
   return {
     Store: require('./yayson/store')(utils),
     Presenter: presenter({
@@ -70,7 +70,7 @@ Adapter = (function() {
   };
 
   Adapter.id = function(model) {
-    return this.get(model, 'id');
+    return "" + (this.get(model, 'id'));
   };
 
   return Adapter;
@@ -90,13 +90,13 @@ module.exports = {
 
 },{"./sequelize":4}],4:[function(require,module,exports){
 var Adapter, SequelizeAdapter,
-  __hasProp = {}.hasOwnProperty,
-  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+  hasProp = {}.hasOwnProperty;
 
 Adapter = require('../adapter');
 
-SequelizeAdapter = (function(_super) {
-  __extends(SequelizeAdapter, _super);
+SequelizeAdapter = (function(superClass) {
+  extend(SequelizeAdapter, superClass);
 
   function SequelizeAdapter() {
     return SequelizeAdapter.__super__.constructor.apply(this, arguments);
@@ -162,6 +162,9 @@ module.exports = function(utils, adapter) {
         return null;
       }
       attributes = utils.clone(adapter.get(instance));
+      if ('id' in attributes) {
+        delete attributes['id'];
+      }
       relationships = this.relationships();
       for (key in relationships) {
         delete attributes[key];
@@ -170,9 +173,9 @@ module.exports = function(utils, adapter) {
     };
 
     Presenter.prototype.includeRelationships = function(scope, instance) {
-      var data, factory, key, presenter, relationships, _results;
+      var data, factory, key, presenter, relationships, results;
       relationships = this.relationships();
-      _results = [];
+      results = [];
       for (key in relationships) {
         factory = relationships[key] || (function() {
           throw new Error("Presenter for " + key + " in " + this.type + " is not defined");
@@ -180,14 +183,14 @@ module.exports = function(utils, adapter) {
         presenter = new factory(scope);
         data = adapter.get(instance, key);
         if (data != null) {
-          _results.push(presenter.toJSON(data, {
+          results.push(presenter.toJSON(data, {
             include: true
           }));
         } else {
-          _results.push(void 0);
+          results.push(void 0);
         }
       }
-      return _results;
+      return results;
     };
 
     Presenter.prototype.buildRelationships = function(instance) {
@@ -226,20 +229,20 @@ module.exports = function(utils, adapter) {
     };
 
     Presenter.prototype.toJSON = function(instanceOrCollection, options) {
-      var added, collection, instance, links, model, relationships, _base, _base1, _base2;
+      var added, base, base1, base2, collection, instance, links, model, relationships;
       if (options == null) {
         options = {};
       }
       if (options.meta != null) {
         this.scope.meta = options.meta;
       }
-      (_base = this.scope).data || (_base.data = null);
+      (base = this.scope).data || (base.data = null);
       if (instanceOrCollection == null) {
         return this.scope;
       }
       if (instanceOrCollection instanceof Array) {
         collection = instanceOrCollection;
-        (_base1 = this.scope).data || (_base1.data = []);
+        (base1 = this.scope).data || (base1.data = []);
         collection.forEach((function(_this) {
           return function(instance) {
             return _this.toJSON(instance);
@@ -262,7 +265,7 @@ module.exports = function(utils, adapter) {
           model.links = links;
         }
         if (options.include) {
-          (_base2 = this.scope).included || (_base2.included = []);
+          (base2 = this.scope).included || (base2.included = []);
           if (!utils.any(this.scope.included.concat(this.scope.data), function(i) {
             return i.id === model.id;
           })) {
@@ -301,13 +304,13 @@ module.exports = function(utils, adapter) {
     };
 
     Presenter.toJSON = function() {
-      var _ref;
-      return (_ref = new this).toJSON.apply(_ref, arguments);
+      var ref;
+      return (ref = new this).toJSON.apply(ref, arguments);
     };
 
     Presenter.render = function() {
-      var _ref;
-      return (_ref = new this).render.apply(_ref, arguments);
+      var ref;
+      return (ref = new this).render.apply(ref, arguments);
     };
 
     return Presenter;
@@ -340,20 +343,20 @@ module.exports = function(utils) {
     };
 
     Store.prototype.toModel = function(rec, type, models) {
-      var data, key, model, rel, resolve, _base, _name, _ref;
+      var base, data, key, model, name, ref, rel, resolve;
       model = utils.clone(rec.attributes) || {};
       model.id = rec.id;
       models[type] || (models[type] = {});
-      (_base = models[type])[_name = rec.id] || (_base[_name] = model);
+      (base = models[type])[name = rec.id] || (base[name] = model);
       if (rec.relationships != null) {
-        _ref = rec.relationships;
-        for (key in _ref) {
-          rel = _ref[key];
+        ref = rec.relationships;
+        for (key in ref) {
+          rel = ref[key];
           data = rel.data;
           resolve = (function(_this) {
-            return function(_arg) {
+            return function(arg) {
               var id, type;
-              type = _arg.type, id = _arg.id;
+              type = arg.type, id = arg.id;
               return _this.find(type, id, models);
             };
           })(this);
@@ -482,9 +485,9 @@ module.exports = function(_, Q) {
   }
   return utils = {
     find: _.find || function(arr, callback) {
-      var elem, _i, _len;
-      for (_i = 0, _len = arr.length; _i < _len; _i++) {
-        elem = arr[_i];
+      var elem, i, len;
+      for (i = 0, len = arr.length; i < len; i++) {
+        elem = arr[i];
         if (callback(elem)) {
           return elem;
         }
@@ -492,10 +495,10 @@ module.exports = function(_, Q) {
       return void 0;
     },
     filter: _.filter || function(arr, callback) {
-      var elem, res, _i, _len;
+      var elem, i, len, res;
       res = [];
-      for (_i = 0, _len = arr.length; _i < _len; _i++) {
-        elem = arr[_i];
+      for (i = 0, len = arr.length; i < len; i++) {
+        elem = arr[i];
         if (callback(elem)) {
           res.push(elem);
         }

--- a/src/yayson/adapter.coffee
+++ b/src/yayson/adapter.coffee
@@ -5,6 +5,6 @@ class Adapter
     model
 
   @id: (model) ->
-    @get model, 'id'
+    "#{@get model, 'id'}"
 
 module.exports = Adapter

--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -25,6 +25,8 @@ module.exports = (utils, adapter) ->
     attributes: (instance) ->
       return null unless instance?
       attributes = utils.clone adapter.get instance
+      if 'id' of attributes
+        delete attributes['id']
       relationships = @relationships()
       for key of relationships
         delete attributes[key]

--- a/test/yayson/adapter.coffee
+++ b/test/yayson/adapter.coffee
@@ -14,4 +14,4 @@ describe 'Adapter', ->
 
   it 'should get the id', ->
     id = Adapter.id {id: 5}
-    expect(id).to.eq 5
+    expect(id).to.eq '5'

--- a/test/yayson/adapters/sequelize.coffee
+++ b/test/yayson/adapters/sequelize.coffee
@@ -31,4 +31,4 @@ describe 'SequelizeAdapter', ->
         5
 
     id = SequelizeAdapter.id model
-    expect(id).to.eq 5
+    expect(id).to.eq '5'

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -14,9 +14,8 @@ describe 'Presenter', ->
     expect(json).to.deep.equal
       data:
         type: 'objects'
-        id: 5
+        id: '5'
         attributes:
-          id: 5
           foo: 'bar'
 
   it 'create json structure of an array of objects', ->
@@ -25,15 +24,13 @@ describe 'Presenter', ->
     expect(json).to.deep.equal
       data: [{
         type: 'objects'
-        id: 1
+        id: '1'
         attributes:
-          id: 1
           foo: 'bar'
       },{
         type: 'objects'
-        id: 2
+        id: '2'
         attributes:
-          id: 2
           foo: 'baz'
       }]
 
@@ -43,9 +40,8 @@ describe 'Presenter', ->
     expect(json).to.deep.equal
       data: [
         type: 'objects'
-        id: 1
-        attributes:
-          id: 1
+        id: '1'
+        attributes: {}
       ]
 
   it 'should serialize relations', ->
@@ -73,24 +69,22 @@ describe 'Presenter', ->
     expect(json).to.deep.equal
       data:
         type: 'cars'
-        id: 1
-        attributes:
-          id: 1
+        id: '1'
+        attributes: {}
         relationships:
           motor:
             data:
               type: 'motors'
-              id: 2
+              id: '2'
       included: [
         type: 'motors'
-        id: 2
-        attributes:
-          id: 2
+        id: '2'
+        attributes: {}
         relationships:
           car:
             data:
               type: 'cars'
-              id: 1
+              id: '1'
       ]
 
   it 'should include self link', ->
@@ -159,9 +153,8 @@ describe 'Presenter', ->
     expect(json).to.deep.equal
       data:
         type: 'objects'
-        id: 5
+        id: '5'
         attributes:
-          id: 5
           foo: 'bar'
 
   it 'should add meta', ->


### PR DESCRIPTION
Presenter was incorrect in the way the `id` was handled. In particularly:
1. Based on [Resource Identification](http://jsonapi.org/format/#document-structure-resource-identification) `"id"` **MUST** be a string.

> Every resource object MUST contain an "id" member and a "type" member. The value of each of these members MUST be a string.
1. Regarding existance of `"id"` in `"attributes"` [Attributes](http://jsonapi.org/format/#document-structure-resource-attributes)

> The value of the "attributes" key is a JSON object (an "attributes object") that represents information about the resource object it is contained within.
> 
> The top level of this object shares a namespace with the members of relationships and MUST NOT contain id or type members. Apart from these restrictions, this object can contain members keyed by any string valid for this specification.
