### PR TITLE
Change optional require format to make webpack happier

### DIFF
--- a/src/yayson.coffee
+++ b/src/yayson.coffee
@@ -1,18 +1,11 @@
-
-tryRequire = (dep) ->
-  try
-    require dep
-  catch
-    undefined
-
 @window ||= {}
 
 Q = @window.Q
 _ = @window._
 
-Q ||= tryRequire 'q'
-_ ||= tryRequire 'lodash/dist/lodash.underscore'
-_ ||= tryRequire 'underscore'
+Q ||= (try require? 'q')
+_ ||= (try require? 'lodash/dist/lodash.underscore')
+_ ||= (try require? 'underscore')
 
 utils = require('./yayson/utils')(_, Q)
 
@@ -31,4 +24,6 @@ module.exports = ({adapter} = {}) ->
   Store: require('./yayson/store')(utils)
   Presenter: presenter({adapter})
   Adapter: Adapter
+
+
 


### PR DESCRIPTION
Webpack doesn't like the current way tryRequire works because it is requiring an expression, which can't be statically analyzed.

```
WARNING in ./~/yayson/lib/yayson.js
Critical dependencies:
5:11-23 the request of a dependency is an expression
 @ ./~/yayson/lib/yayson.js 5:11-23
```

This method of doing the same logic doesn't cause it to fail in the same way, and warnings can be handled with aliases in the webpack config (https://github.com/webpack/webpack/issues/733#issuecomment-73891645)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/confetti/yayson/11)

<!-- Reviewable:end -->
