### PR TITLE
Add support for links in relationships when no data is provided

### DIFF
--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -55,9 +55,9 @@ module.exports = (utils, adapter) ->
             id: @constructor.adapter.id d
             type: presenter::type
         build = (d) =>
-          rel =
-            data:
-              buildData(d)
+          rel = {}
+          if d?
+            rel.data = buildData(d)
           if links[key]?
             rel.links = buildLinks links[key]
           rel
@@ -65,10 +65,8 @@ module.exports = (utils, adapter) ->
         relationships[key] ||= {}
         relationships[key]= if data instanceof Array
           data: data.map buildData
-        else if data?
-          build data
         else
-          null
+          build data
       relationships
 
     buildSelfLink: (instance) ->
@@ -128,4 +126,3 @@ module.exports = (utils, adapter) ->
 
 
   module.exports = Presenter
-

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -197,6 +197,27 @@ describe 'Presenter', ->
     expect(json.data.relationships.car.links.self).to.eq '/cars/3/linkage/car'
     expect(json.data.relationships.car.links.related).to.eq '/cars/3/car'
 
+  it 'should handle links in relationships without data', ->
+    class CarPresenter extends Presenter
+      type: 'cars'
+
+      relationships: ->
+        car: CarPresenter
+
+      selfLinks: (instance) ->
+        '/cars/' + @id(instance)
+
+      links: (instance) ->
+        car:
+          self: @selfLinks(instance) + '/linkage/car'
+          related: @selfLinks(instance) + '/car'
+
+    json = CarPresenter.render(id: 3)
+    expect(json.data.links.self).to.eq '/cars/3'
+    expect(json.data.relationships.car.links.self).to.eq '/cars/3/linkage/car'
+    expect(json.data.relationships.car.links.related).to.eq '/cars/3/car'
+    expect(json.data.relationships.car.data).to.eq undefined
+
   it 'should serialize in pure JS', ->
     `
     var EventPresenter = function () { Presenter.call(this); }


### PR DESCRIPTION
Test included.

The importance of supporting this case is to give the possibility to generate a resource in JSONAPI with links and no data. This is useful when defining accessible relationships without the include query param.
