### PR TITLE
Fixes Store#sync for relationships without links

### DIFF
--- a/src/yayson/store.coffee
+++ b/src/yayson/store.coffee
@@ -34,7 +34,7 @@ module.exports = (utils) ->
             {}
 
           # Model of the relation
-          currentModel = model[key] 
+          currentModel = model[key]
 
           if currentModel?
               linksAttr = currentModel.links

--- a/src/yayson/store.coffee
+++ b/src/yayson/store.coffee
@@ -33,16 +33,19 @@ module.exports = (utils) ->
           else
             {}
 
-          currentModel = model[key]
-          linksAttr = currentModel.links
-          # Getter allows accessing a model attribute called 'links',
-          # which would otherwise be overwritten by resource links.
-          currentModel.get = (attrName) ->
-              if attrName == 'links' then linksAttr else currentModel[attrName]
+          # Model of the relation
+          currentModel = model[key] 
 
-          currentModel.links = links || {}
+          if currentModel?
+              linksAttr = currentModel.links
+
+              # Getter allows accessing a model attribute called 'links',
+              # which would otherwise be overwritten by resource links.
+              currentModel.get = (attrName) ->
+                  if attrName == 'links' then linksAttr else currentModel[attrName]
+
+              currentModel.links = links || {}
       model
-
 
     findRecord: (type, id) ->
       utils.find @records, (r) ->

--- a/test/yayson/store.coffee
+++ b/test/yayson/store.coffee
@@ -62,6 +62,24 @@ describe 'Store', ->
     images = @store.findAll 'images'
     expect(images.length).to.eq 1
 
+  it 'should handle relationship elements without links attribute', ->
+      @store.sync
+        data:
+            type: 'events'
+            id: 1
+            attributes:
+                name: 'Demo'
+            relationships:
+                image:
+                    data: {
+                        type: 'images',
+                        id: 2
+                    }
+       event = @store.find 'events', 1
+       console.log event
+       expect(event.name).to.equal 'Demo'
+       expect(event.image).to.be.null
+
   it 'should handle circular relations', ->
     @store.sync
       data:

--- a/test/yayson/store.coffee
+++ b/test/yayson/store.coffee
@@ -76,7 +76,7 @@ describe 'Store', ->
                         id: 2
                     }
        event = @store.find 'events', 1
-       console.log event
+
        expect(event.name).to.equal 'Demo'
        expect(event.image).to.be.null
 


### PR DESCRIPTION
Solves an issue (#17) causing Store#sync to throw an Error, whenever a record with
relationships (without links and without included) is being stored.
