### PR TITLE
Objects of identical ID not included when rendered

### DIFF
--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -99,7 +99,9 @@ module.exports = (utils, adapter) ->
 
         if options.include
           @scope.included ||= []
-          unless utils.any(@scope.included.concat(@scope.data), (i) -> i.id == model.id)
+          unless utils.any(@scope.included.concat(@scope.data), (i) ->
+            i.id == model.id && i.type == model.type
+          )
             @scope.included.push model
           else
             added = false

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -99,6 +99,13 @@ describe 'Presenter', ->
         wheels: WheelPresenter
 
     wheels =[
+      # Intentionally adding a relation that uses the same ID as the base data
+      # to prevent a regression where data of different types but of the same id
+      # would not get included
+      {
+        id: 1
+        bike: null
+      },
       {
         id: 2
         bike: null
@@ -109,7 +116,7 @@ describe 'Presenter', ->
       }
     ]
 
-    bike = 
+    bike =
       id: 1
       wheels: wheels
 
@@ -127,6 +134,10 @@ describe 'Presenter', ->
             data:[
               {
                 type: 'wheels'
+                id: '1'
+              },
+              {
+                type: 'wheels'
                 id: '2'
               },
               {
@@ -135,6 +146,16 @@ describe 'Presenter', ->
               }
             ]
       included: [
+        {
+          type: 'wheels'
+          id: '1'
+          attributes: {}
+          relationships:
+            bike:
+              data:
+                type: 'bikes'
+                id: '1'
+        },
         {
           type: 'wheels'
           id: '2'


### PR DESCRIPTION
The current implementation of `Presenter.toJSON` with the `include: true` option only compares existing objects by `id` and completely ignores the `type`. This results in comparing `bike.id == 1` with `wheel.id == 1` and concludes that they are the same object and therefore should not be added again to the `included` array.
