### PR TITLE
Build a standalone js file for web use without module/package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ This will give you the parsed event with all its relationships.
 
 Recommended way is to use it via [webpack](https://github.com/webpack/webpack) or similar build system wich lets you just require the package as usual.
 
-If you just want to try it out, copy the file `dist/yayson-standalone.js` to your project. Then simply include it:
+If you just want to try it out, copy the file `dist/yayson.js` to your project. Then simply include it:
 ```html
-    <script src="./lib/yayson-standalone.js"></script>
+    <script src="./lib/yayson.js"></script>
 ```
-Then you can `var yayson = yayson()` use the `yayson.Presenter` and `yayson.Store` as usual. 
+Then you can `var yayson = window.yayson()` use the `yayson.Presenter` and `yayson.Store` as usual.
 
 ### Browser support
 

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ This will give you the parsed event with all its relationships.
 
 Recommended way is to use it via [webpack](https://github.com/webpack/webpack) or similar build system wich lets you just require the package as usual.
 
-If you just want to try it out, copy the file `dist/yayson.js` to your project. Then simply include it:
+If you just want to try it out, copy the file `dist/yayson-standalone.js` to your project. Then simply include it:
 ```html
-    <script src="./lib/yayson.js"></script>
+    <script src="./lib/yayson-standalone.js"></script>
 ```
-Then you can `var yayson = require('yayson')()` use the `yayson.Presenter` and `yayson.Store` as usual. 
+Then you can `var yayson = yayson()` use the `yayson.Presenter` and `yayson.Store` as usual. 
 
 ### Browser support
 
@@ -165,5 +165,3 @@ Then you can `var yayson = require('yayson')()` use the `yayson.Presenter` and `
 #### Untested, but should work
 - IE 9+
 - Android
-
-

--- a/dist/yayson.js
+++ b/dist/yayson.js
@@ -1,4 +1,4 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.yayson=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 var Adapter, Q, _, adapters, lookupAdapter, presenter, presenterFactory, utils;
 
 this.window || (this.window = {});
@@ -10,19 +10,19 @@ _ = this.window._;
 Q || (Q = ((function() {
   try {
     return typeof require === "function" ? require('q') : void 0;
-  } catch (_error) {}
+  } catch (undefined) {}
 })()));
 
 _ || (_ = ((function() {
   try {
     return typeof require === "function" ? require('lodash/dist/lodash.underscore') : void 0;
-  } catch (_error) {}
+  } catch (undefined) {}
 })()));
 
 _ || (_ = ((function() {
   try {
     return typeof require === "function" ? require('underscore') : void 0;
-  } catch (_error) {}
+  } catch (undefined) {}
 })()));
 
 utils = require('./yayson/utils')(_, Q);
@@ -5557,4 +5557,5 @@ module.exports = function(_, Q) {
 
 
 
-},{}]},{},[1]);
+},{}]},{},[1])(1)
+});

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -10,15 +10,10 @@ ecstatic = require 'ecstatic'
 serverport = 5005
 
 gulp.task 'browserify', ->
-  browserify('./src/yayson.coffee', {extensions: ['.coffee'], ignoreMissing: true})
-    .transform(coffeeify)
-    .bundle()
-    .pipe(source('yayson.js'))
-    .pipe(gulp.dest('./dist/'))
   browserify('./src/yayson.coffee', {extensions: ['.coffee'], ignoreMissing: true, standalone: 'yayson'})
     .transform(coffeeify)
     .bundle()
-    .pipe(source('yayson-standalone.js'))
+    .pipe(source('yayson.js'))
     .pipe(gulp.dest('./dist/'))
 
 gulp.task 'build', ->

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -15,6 +15,11 @@ gulp.task 'browserify', ->
     .bundle()
     .pipe(source('yayson.js'))
     .pipe(gulp.dest('./dist/'))
+  browserify('./src/yayson.coffee', {extensions: ['.coffee'], ignoreMissing: true, standalone: 'yayson'})
+    .transform(coffeeify)
+    .bundle()
+    .pipe(source('yayson-standalone.js'))
+    .pipe(gulp.dest('./dist/'))
 
 gulp.task 'build', ->
   gulp.src('./src/**/*.coffee')


### PR DESCRIPTION
The readme misleads one to believing you can just drop the yayson.js in and it will work. Unfortunately, that requires webpack/requirejs/etc to work in a complete form. For the quick trial and example of the lib it makes more sense to bundle a standalone JS that works without extra bells and whistles.
