### PR TITLE
Add 'type' attribute to Sequelize adapter

### DIFF
--- a/src/yayson/adapter.coffee
+++ b/src/yayson/adapter.coffee
@@ -6,5 +6,6 @@ class Adapter
 
   @id: (model) ->
     "#{@get model, 'id'}"
-
+  @type: (model) ->
+    return model.type || "objects"
 module.exports = Adapter

--- a/src/yayson/adapters/sequelize.coffee
+++ b/src/yayson/adapters/sequelize.coffee
@@ -4,5 +4,5 @@ class SequelizeAdapter extends Adapter
   @get: (model, key) ->
     model.get(key) if model?
   @type: (model) ->
-    return model.Model.getTableName();
+    return model.Model.getTableName()
 module.exports = SequelizeAdapter

--- a/src/yayson/adapters/sequelize.coffee
+++ b/src/yayson/adapters/sequelize.coffee
@@ -3,5 +3,6 @@ Adapter = require '../adapter'
 class SequelizeAdapter extends Adapter
   @get: (model, key) ->
     model.get(key) if model?
-
+  @type: (model) ->
+    return model.Model.getTableName();
 module.exports = SequelizeAdapter

--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -8,7 +8,8 @@ module.exports = (utils, adapter) ->
         self: link
 
     @adapter: adapter
-    type: 'objects'
+    type: (instance) ->
+      @constructor.adapter.type instance
 
     constructor: (scope = {}) ->
       @scope = scope
@@ -90,7 +91,7 @@ module.exports = (utils, adapter) ->
         added = true
         model  =
           id: @id instance
-          type: @type
+          type: @type instance
           attributes: @attributes instance
         relationships = @buildRelationships instance
         model.relationships = relationships if relationships?


### PR DESCRIPTION
Attribute `'type'` always is `'objects'`, this PR represent `'type'` to Sequelize.Model.getTableName().
P.S. Check coffee code, i'm only test it on plain JS.
