### PR TITLE
Don't include relationship if it's empty

### DIFF
--- a/dist/yayson.js
+++ b/dist/yayson.js
@@ -10,19 +10,19 @@ _ = this.window._;
 Q || (Q = ((function() {
   try {
     return typeof require === "function" ? require('q') : void 0;
-  } catch (_error) {}
+  } catch (error) {}
 })()));
 
 _ || (_ = ((function() {
   try {
     return typeof require === "function" ? require('lodash/dist/lodash.underscore') : void 0;
-  } catch (_error) {}
+  } catch (error) {}
 })()));
 
 _ || (_ = ((function() {
   try {
     return typeof require === "function" ? require('underscore') : void 0;
-  } catch (_error) {}
+  } catch (error) {}
 })()));
 
 utils = require('./yayson/utils')(_, Q);
@@ -5222,6 +5222,9 @@ module.exports = function(utils, adapter) {
           }
         } else {
           relationships[key] = build(data);
+        }
+        if (!(relationships[key].length > 0)) {
+          delete relationships[key];
         }
       }
       return relationships;

--- a/dist/yayson.js
+++ b/dist/yayson.js
@@ -10,19 +10,19 @@ _ = this.window._;
 Q || (Q = ((function() {
   try {
     return typeof require === "function" ? require('q') : void 0;
-  } catch (error) {}
+  } catch (_error) {}
 })()));
 
 _ || (_ = ((function() {
   try {
     return typeof require === "function" ? require('lodash/dist/lodash.underscore') : void 0;
-  } catch (error) {}
+  } catch (_error) {}
 })()));
 
 _ || (_ = ((function() {
   try {
     return typeof require === "function" ? require('underscore') : void 0;
-  } catch (error) {}
+  } catch (_error) {}
 })()));
 
 utils = require('./yayson/utils')(_, Q);
@@ -5222,9 +5222,6 @@ module.exports = function(utils, adapter) {
           }
         } else {
           relationships[key] = build(data);
-        }
-        if (!(relationships[key].length > 0)) {
-          delete relationships[key];
         }
       }
       return relationships;

--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -69,6 +69,7 @@ module.exports = (utils, adapter) ->
             relationships[key].links = buildLinks links[key]
         else
           relationships[key]= build data
+        delete relationships[key] unless relationships[key].length > 0
       relationships
 
     buildSelfLink: (instance) ->

--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -51,7 +51,7 @@ module.exports = (utils, adapter) ->
         data = @constructor.adapter.get instance, key
         presenter = rels[key]
         buildData = (d) =>
-          data =
+          data = 
             id: @constructor.adapter.id d
             type: presenter::type
         build = (d) =>

--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -51,7 +51,7 @@ module.exports = (utils, adapter) ->
         data = @constructor.adapter.get instance, key
         presenter = rels[key]
         buildData = (d) =>
-          data = 
+          data =
             id: @constructor.adapter.id d
             type: presenter::type
         build = (d) =>
@@ -69,7 +69,7 @@ module.exports = (utils, adapter) ->
             relationships[key].links = buildLinks links[key]
         else
           relationships[key]= build data
-        delete relationships[key] unless relationships[key].length > 0
+        delete relationships[key] unless Object.keys(relationships[key]).length > 0
       relationships
 
     buildSelfLink: (instance) ->

--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -60,6 +60,8 @@ module.exports = (utils, adapter) ->
             rel.data = buildData(d)
           if links[key]?
             rel.links = buildLinks links[key]
+          else unless d?
+            rel.data = null
           rel
         relationships ||= {}
         relationships[key] ||= {}
@@ -69,7 +71,6 @@ module.exports = (utils, adapter) ->
             relationships[key].links = buildLinks links[key]
         else
           relationships[key]= build data
-        delete relationships[key] unless Object.keys(relationships[key]).length > 0
       relationships
 
     buildSelfLink: (instance) ->

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -282,7 +282,7 @@ describe 'Presenter', ->
     expect(json.data.relationships.car.links.related).to.eq '/cars/3/car'
     expect(json.data.relationships.car.data).to.eq undefined
 
-  it.only 'should not include relationships with nothing in them', ->
+  it 'should not include relationships with nothing in them', ->
     class CarPresenter extends Presenter
       type: 'cars'
 

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -282,6 +282,16 @@ describe 'Presenter', ->
     expect(json.data.relationships.car.links.related).to.eq '/cars/3/car'
     expect(json.data.relationships.car.data).to.eq undefined
 
+  it.only 'should not include relationships with nothing in them', ->
+    class CarPresenter extends Presenter
+      type: 'cars'
+
+      relationships: ->
+        car: CarPresenter
+
+    json = CarPresenter.render(id: 3)
+    expect(json.data.relationships.car).to.eq undefined
+
   it 'should serialize in pure JS', ->
     `
     var EventPresenter = function () { Presenter.call(this); }

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -282,7 +282,7 @@ describe 'Presenter', ->
     expect(json.data.relationships.car.links.related).to.eq '/cars/3/car'
     expect(json.data.relationships.car.data).to.eq undefined
 
-  it 'should not include relationships with nothing in them', ->
+  it 'should render data: null for unspecified relationships', ->
     class CarPresenter extends Presenter
       type: 'cars'
 
@@ -290,7 +290,9 @@ describe 'Presenter', ->
         car: CarPresenter
 
     json = CarPresenter.render(id: 3)
-    expect(json.data.relationships.car).to.eq undefined
+    expect(json.data.relationships).to.deep.equal
+      car:
+        data: null
 
   it 'should serialize in pure JS', ->
     `


### PR DESCRIPTION
According to the standard (http://jsonapi.org/format/#document-resource-object-relationships)

"A “relationship object” MUST contain at least one of the following: [links, data, meta]"

But if you specify `relationships()` for a presenter and then don't provide that relationship when you `render`, the output is `"relationships": {"your_relationship": {}}`. No links, no data, no meta. (Look at my test for a clearer description.)

My parser (rails' ActiveModelSerializer) refuses to parse this.