### PR TITLE
Don't expose id if not specified

### DIFF
--- a/src/yayson/adapter.coffee
+++ b/src/yayson/adapter.coffee
@@ -5,6 +5,9 @@ class Adapter
     model
 
   @id: (model) ->
-    "#{@get model, 'id'}"
+    id = @get model, 'id'
+    if id == undefined
+      return id
+    return "#{id}"
 
 module.exports = Adapter

--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -92,6 +92,7 @@ module.exports = (utils, adapter) ->
           id: @id instance
           type: @type
           attributes: @attributes instance
+        delete model.id if model.id == undefined
         relationships = @buildRelationships instance
         model.relationships = relationships if relationships?
         links = @buildSelfLink instance

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -34,6 +34,15 @@ describe 'Presenter', ->
           foo: 'baz'
       }]
 
+  it 'should not include id if not specified', ->
+    obj = {foo: 'bar'}
+    json = Presenter.toJSON(obj)
+    expect(json).to.deep.equal
+      data:
+        type: 'objects'
+        attributes:
+          foo: 'bar'
+
   it 'should not dup object', ->
     obj = [{id: 1}, {id: 1}]
     json = Presenter.toJSON(obj)


### PR DESCRIPTION
When a client creates an object, it's not usually the client setting the id. Yayson currently produces `id: "undefined"` when rendering an object without an id. This complicates things for the server creating the actual object.

According to the example in http://jsonapi.org/format/#crud-creating, it seems like it's perfectly ok to omit the id of an object.