### PR TITLE
Updated to use id function on the relationship presenter

### DIFF
--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -51,8 +51,9 @@ module.exports = (utils, adapter) ->
         data = @constructor.adapter.get instance, key
         presenter = rels[key]
         buildData = (d) =>
+          presenterInstance = new presenter 
           data = 
-            id: @constructor.adapter.id d
+            id: presenterInstance.id d
             type: presenter::type
         build = (d) =>
           rel = {}

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -314,6 +314,7 @@ describe 'Presenter', ->
 
     json = CarPresenter.render car
     expect(json.data.relationships.wheels.data[0].id).to.eq 123
+    expect(json.included[0].id).to.eq 123
 
   it 'should render data: null for unspecified relationships', ->
     class CarPresenter extends Presenter

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -256,7 +256,7 @@ describe 'Presenter', ->
       }
     ]
 
-    car = 
+    car =
       id: 1
       cars: cars
 
@@ -290,6 +290,30 @@ describe 'Presenter', ->
     expect(json.data.relationships.car.links.self).to.eq '/cars/3/linkage/car'
     expect(json.data.relationships.car.links.related).to.eq '/cars/3/car'
     expect(json.data.relationships.car.data).to.eq undefined
+
+  it 'should use id function on the relationship presenter', ->
+    class CarPresenter extends Presenter
+      type: 'cars'
+      relationships: ->
+        wheels: WheelPresenter
+
+    class WheelPresenter extends Presenter
+      type: 'wheels'
+      id: (instance) ->
+        return instance.fakeId
+
+    car = {
+      id: 2
+      wheels: [
+        {
+          fakeId: 123,
+          id: 456
+        }
+      ]
+    }
+
+    json = CarPresenter.render car
+    expect(json.data.relationships.wheels.data[0].id).to.eq 123
 
   it 'should render data: null for unspecified relationships', ->
     class CarPresenter extends Presenter


### PR DESCRIPTION
This allows users who have overridden the id function on their presenter for that same id function to run when building the relationship.

For example:
On a product I could have stored the "id" in the serialNumber property on an object i'm using on the client side, but when sending it to my api I want to set it as my id.

On a sidenote:
Thanks for creating this package it has saved me so much time when having to interact with my JSON API.