### PR TITLE
Adds support for local and reference links and meta data per spec

### DIFF
--- a/src/yayson/store.coffee
+++ b/src/yayson/store.coffee
@@ -3,7 +3,7 @@ module.exports = (utils) ->
 
   class Record
     constructor: (options) ->
-      {@id, @type, @attributes, @relationships} = options
+      {@id, @type, @attributes, @relationships, @links, @meta} = options
 
   class Store
     constructor: (options) ->
@@ -14,15 +14,31 @@ module.exports = (utils) ->
       @relations = {}
 
     toModel: (rec, type, models) ->
+
       model = utils.clone(rec.attributes) || {}
+
       model.id = rec.id
       model.type = rec.type
       models[type] ||= {}
       models[type][rec.id] ||= model
+
+      if model.hasOwnProperty 'meta'
+        model.attributes = {meta: model.meta};
+        delete model.meta;
+
+      if rec.meta?
+        model.meta = rec.meta
+
+      if rec.links?
+        model.links = rec.links
+
       if rec.relationships?
         for key, rel of rec.relationships
+
           data = rel.data
           links = rel.links
+          meta = rel.meta
+
           model[key] = null
           continue unless data? or links?
           resolve = ({type, id}) =>
@@ -38,8 +54,10 @@ module.exports = (utils) ->
           currentModel = model[key]
 
           if currentModel?
-            # We overwrite the links attribute here since its reserved in the spec anyway
-            currentModel.links = links || {}
+            # retain the links and meta from the relationship entry
+            # use as underscore property name because the currentModel may also have a link and meta reference
+            currentModel._links = links || {}
+            currentModel._meta = meta || {}
 
       model
 
@@ -97,13 +115,18 @@ module.exports = (utils) ->
       return null unless recs?
 
       models = {}
+      result = null;
+
       if recs instanceof Array
-        recs.map (rec) =>
+        result = recs.map (rec) =>
           @toModel rec, rec.type, models
       else
-        @toModel recs, recs.type, models
+        result = @toModel recs, recs.type, models
 
+      if body.hasOwnProperty 'links'
+        result.links = body.links;
 
+      if body.hasOwnProperty 'meta'
+        result.meta = body.meta;
 
-
-
+      result

--- a/test/yayson/store.coffee
+++ b/test/yayson/store.coffee
@@ -1,5 +1,4 @@
 expect = require('chai').expect
-
 Store = require('../../src/yayson.coffee')().Store
 
 describe 'Store', ->
@@ -264,6 +263,62 @@ describe 'Store', ->
               self: 'http://example.com/events/1/relationships/images'
 
     event = @store.find 'events', 1
+
     expect(event.name).to.equal 'Demo'
-    expect(event.images.links).to.deep.equal
+    expect(event.images._links).to.deep.equal
         self: 'http://example.com/events/1/relationships/images'
+
+  it 'should retain links and meta', ->
+    result = @store.sync
+      links:
+        self: 'http://example.com/events'
+        next: 'http://example.com/events?page[offset]=2'
+      meta:
+        name: 'top level meta data'
+        value: 1
+      data: [
+        type: 'events'
+        id: 1
+        meta:
+          name: 'second level meta'
+          value: 2
+        attributes:
+          name: 'Demo'
+          article:
+            name: 'An Article test'
+            teaser: 'this is a teaser...'
+            body: 'this is an article body'
+            meta:
+              author: 'John Doe'
+              date: '2017-06-26'
+          meta:
+            name: 'attribute nested meta'
+            value: 3
+        relationships:
+          comment:
+            links:
+              self: 'http://example.com/events/1/relationships/comment'
+              related: 'http://example.com/events/1/comment'
+            data:
+              type: 'comment',
+              id: 2
+      ]
+      included: [
+        type: 'comment'
+        id: 2
+        attributes:
+          name: 'Comment'
+          details:
+            user: 'micha3ldavid'
+            body: 'this is a comment...'
+        links:
+          self: 'http://example.com/comment/2'
+        meta:
+          author: 'John Doe'
+          date: '2017-06-26'
+      ]
+
+    expect(result.meta).to.deep.equal {name: 'top level meta data', value: 1}
+    expect(result[0].article.meta).to.deep.equal {author: 'John Doe', date: '2017-06-26'}
+    expect(result[0].comment.meta).to.deep.equal {author: 'John Doe', date: '2017-06-26'}
+    expect(result[0].comment._links).to.deep.equal {self: 'http://example.com/events/1/relationships/comment', related: 'http://example.com/events/1/comment'}


### PR DESCRIPTION
Currently 'meta' properties are not retained but are part of the JSON API spec. This PR adds retention to the meta on all levels (base + deep). Second thing I added is retention of both reference and related 'links.' See the 'comment' area in my mocha test example for the use case (ie: '_links' refers to the relationship reference while 'links' is carried over from the local object).