### PR TITLE
[fix] Updated dist/yayson.js 'lodash' require

### DIFF
--- a/dist/yayson.js
+++ b/dist/yayson.js
@@ -15,7 +15,7 @@ Q || (Q = ((function() {
 
 _ || (_ = ((function() {
   try {
-    return typeof require === "function" ? require('lodash/dist/lodash.underscore') : void 0;
+    return typeof require === "function" ? require('lodash') : void 0;
   } catch (_error) {}
 })()));
 
@@ -63,7 +63,7 @@ module.exports = function(arg) {
 
 
 
-},{"./yayson/adapter":4,"./yayson/adapters":5,"./yayson/presenter":7,"./yayson/store":8,"./yayson/utils":9,"lodash/dist/lodash.underscore":3,"q":2,"underscore":2}],2:[function(require,module,exports){
+},{"./yayson/adapter":4,"./yayson/adapters":5,"./yayson/presenter":7,"./yayson/store":8,"./yayson/utils":9,"lodash":3,"q":2,"underscore":2}],2:[function(require,module,exports){
 
 },{}],3:[function(require,module,exports){
 (function (global){


### PR DESCRIPTION
# Related Issue

https://github.com/confetti/yayson/issues/32

# Overview

With the updated version of lodash, our require location also needs to change. This was updated in yayson.coffee, but was not in dist/yayson.js

This is not a high-priority change and does not break anything for me, but it does give a warning during the build about not being able to require lodash/dist/lodash.underscore