### PR TITLE
Allow top-level links as a render option

### DIFF
--- a/src/yayson/presenter.coffee
+++ b/src/yayson/presenter.coffee
@@ -77,6 +77,7 @@ module.exports = (utils, adapter) ->
 
     toJSON: (instanceOrCollection, options = {}) ->
       @scope.meta = options.meta if options.meta?
+      @scope.links = options.links if options.links?
       @scope.data ||= null
 
       return @scope unless instanceOrCollection?

--- a/test/yayson/presenter.coffee
+++ b/test/yayson/presenter.coffee
@@ -342,6 +342,12 @@ describe 'Presenter', ->
 
     expect(json.meta.count).to.eq 1
 
+  it 'should add top-level links', -> 
+    obj = {id: 1}
+    json = Presenter.render(obj, links: next: '/obj?page=2')
+
+    expect(json.links.next).to.eq('/obj?page=2')
+
   it 'should exclude id from attributes', ->
     obj = {id: 5, foo: 'bar', type: 'some'}
     json = Presenter.toJSON(obj)


### PR DESCRIPTION
Top-level links are required for paginating per [the spec](https://jsonapi.org/format/#fetching-pagination):

> To paginate the primary data, supply pagination links in the top-level links object.

Yayson does not presently have a way to set the [top-level links](https://jsonapi.org/format/#document-top-level). This PR permits sending links in the render options, similar to meta, to implement this aspect of the spec.

This fixes #31.